### PR TITLE
[initialModel] if redux updates initialModel, update model in FormWra…

### DIFF
--- a/src/reformed.js
+++ b/src/reformed.js
@@ -53,6 +53,16 @@ const makeWrapper = (middleware) => (WrappedComponent) => {
       }
     }
 
+    componentWillReceiveProps(nextProps) {
+      const initialModelOrig = this.props.initialModel
+      const initialModelUpdated = nextProps.initialModel
+      for (let key in initialModelUpdated) {
+        if (initialModelOrig[key] !== initialModelUpdated[key]) {
+          this.setModel(initialModelUpdated)
+        }
+      }
+    }
+
     render () {
       const nextProps = assign({}, this.props, {
         bindInput: this.bindInput,


### PR DESCRIPTION
The library currently does not work well with react-redux's `connect` component for defining an `initialModel`.

Oftentimes store data is update asynchronously (e.g. make an api call when a component mounts and putting the result in the store). `connect` passes these asynchronous changes to this library's `FormWrapper` as props, but these changes are not reflected in `initialModel` data since `FormWrapper` only uses it in its `constructor,` which is not called on prop change.

This PR modifies `FormWrapper` to update its state if `initialModel` changes. Now if any `initialModel` values are not resolved when the component mounts, these values are still displayed.