### PR TITLE
Correct `validateSchema` example variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ compose(
       required: true
     },
     age: {
-      test: (value) => {
-        return value && value > 18
+      test: (value, fail) => {
+        if (!value || value <= 18) {
+          return fail('Age must be 18 or older');
+        }
       }
     }
   })

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ compose(
     },
     age: {
       test: (value) => {
-        return age && age > 18
+        return value && value > 18
       }
     }
   })


### PR DESCRIPTION
Very, very minor readme fix!

The test function gets a `value` argument but the body was referring to an `age` variable (which wouldn't exist here). It should test the `value` parameter (alternatively, rename the `value` argument to `age`).