### PR TITLE
Support custom error generation

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -81,6 +81,12 @@ const createFormContainer = compose(
     username: {
       required: true,
       maxLength: 8,
+      // note: you can optionally generate custom errors via `formatError`
+      // by providing a string or a function that receives context
+      formatError: (context) => {
+        // e.g. return a message id for use with `react-intl` or similar
+        return `errors.username.${context.condition}`;
+      }
     },
     password: {
       // note: my `test` implementation is super basic, `fail` can

--- a/src/validateSchema.js
+++ b/src/validateSchema.js
@@ -8,20 +8,30 @@ const getValidationErrors = (schema, model) => Object.keys(schema).reduce((acc, 
   const value = model[key]
   const rules = schema[key]
 
+  const renderError = (condition, fallback) => {
+    let err;
+    try {
+      err = rules.formatError({ key, value, condition, rules, schema, model });
+    } catch (e) {
+      err = rules.formatError || fallback;
+    }
+    return err;
+  }
+
   if (rules.required && !value) {
-    errors.push(`${key} is required`)
+    errors.push(renderError('required', `${key} is required`))
   }
   if (rules.type && typeof value !== rules.type) {
-    errors.push(`${key} must be of type ${rules.type}, but got ${typeof value}`)
+    errors.push(renderError('type', `${key} must be of type ${rules.type}, but got ${typeof value}`))
   }
   if (rules.minLength) {
     if (!value || value.length < rules.minLength) {
-      errors.push(`${key} must have at least ${rules.minLength} characters`)
+      errors.push(renderError('minLength', `${key} must have at least ${rules.minLength} characters`))
     }
   }
   if (rules.maxLength) {
     if (value && value.length > rules.maxLength) {
-      errors.push(`${key} must not have more than ${rules.maxLength} characters`)
+      errors.push(renderError('maxLength', `${key} must not have more than ${rules.maxLength} characters`))
     }
   }
   if (rules.test) {

--- a/src/validateSchema.js
+++ b/src/validateSchema.js
@@ -9,13 +9,9 @@ const getValidationErrors = (schema, model) => Object.keys(schema).reduce((acc, 
   const rules = schema[key]
 
   const renderError = (condition, fallback) => {
-    let err;
-    try {
-      err = rules.formatError({ key, value, condition, rules, schema, model });
-    } catch (e) {
-      err = rules.formatError || fallback;
-    }
-    return err;
+    return typeof rules.formatError === 'function'
+      ? rules.formatError({ key, value, condition, rules, schema, model })
+      : fallback;
   }
 
   if (rules.required && !value) {


### PR DESCRIPTION
While I know the `validateSchema` module provided is "just for demonstration", it's still very useful and we are considering using it as-is. However, we are also using `react-intl` and would like our errors to be returned as message ids rather than English-only messages. This small change enables both this, as well as many other use-cases where custom error messages would be desirable.