### PR TITLE
Implement Meta Field States (Dirty, Valid, etc.)

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -31,7 +31,7 @@ const MyForm = ({ bindInput, bindToChangeEvent, model, onSubmit, setProperty, sc
           type='text'
           className='form-control'
           placeholder='Username'
-          {...bindInput('username')}
+          {...bindInput('username', { updateOn: 'onBlur', debounce: 100 })}
         />
       </fieldset>
       <fieldset className={cx('form-group', { 'has-danger': !isPasswordValid })}>

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -8,20 +8,18 @@ import compose from 'react-reformed/lib/compose'
 import syncWith from 'react-reformed/lib/syncWith'
 import validateSchema from 'react-reformed/lib/validateSchema'
 
-const contains = (x, xs) => xs && !!~xs.indexOf(x)
-
 /*
  * Here you can create your base form component.
  * Look at how small and sleek it is.
  */
-const MyForm = ({ bindInput, bindToChangeEvent, model, onSubmit, setProperty, schema }) => {
+const MyForm = ({ bindInput, bindCheckbox, model, onSubmit, setProperty, schema }) => {
   const sampleCheckboxOptions = ['foo', 'bar', 'baz']
   const submitHandler = (e) => {
     e.preventDefault()
     onSubmit(model)
   }
-  const isUsernameValid = schema.fields.username.isValid
-  const isPasswordValid = schema.fields.password.isValid
+  const isUsernameValid = schema.fields.username.untouched || schema.fields.username.isValid
+  const isPasswordValid = schema.fields.password.untouched || schema.fields.password.isValid
 
   return (
     <form onSubmit={submitHandler}>
@@ -31,7 +29,7 @@ const MyForm = ({ bindInput, bindToChangeEvent, model, onSubmit, setProperty, sc
           type='text'
           className='form-control'
           placeholder='Username'
-          {...bindInput('username', { updateOn: 'onBlur', debounce: 100 })}
+          {...bindInput('username')}
         />
       </fieldset>
       <fieldset className={cx('form-group', { 'has-danger': !isPasswordValid })}>
@@ -51,8 +49,7 @@ const MyForm = ({ bindInput, bindToChangeEvent, model, onSubmit, setProperty, sc
                 type='checkbox'
                 name='checkboxes'
                 value={value}
-                checked={contains(value, model.checkboxes)}
-                onChange={bindToChangeEvent}
+                {...bindCheckbox('checkboxes', value)}
               />
               {' '}{value}
             </label>
@@ -81,6 +78,7 @@ const createFormContainer = compose(
     username: {
       required: true,
       maxLength: 8,
+      updateOn: 'blur',
       // note: you can optionally generate custom errors via `formatError`
       // by providing a string or a function that receives context
       formatError: (context) => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "David Zukowski <david@zuko.me> (https://zuko.me)",
   "license": "MIT",
   "dependencies": {
+    "debounce": "^1.0.2",
     "hoist-non-react-statics": "^1.2.0",
     "object-assign": "^4.1.0"
   },

--- a/src/reformed.js
+++ b/src/reformed.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import debounce from 'debounce'
 import assign from 'object-assign'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import getComponentName from './_internal/getComponentName'
+
+const contains = (x, xs) => xs && !!~xs.indexOf(x)
 
 const makeWrapper = (middleware) => (WrappedComponent) => {
   class FormWrapper extends React.Component {
@@ -14,7 +15,13 @@ const makeWrapper = (middleware) => (WrappedComponent) => {
       super(props, ctx)
       this.state = {
         model: props.initialModel || {},
+        lastInputEvent: {}
       }
+
+      // Store input interaction flags for the life of this
+      // component outside of state, so they can be updated
+      // during render
+      this.inputFlags = {}
     }
 
     setModel = (model) => {
@@ -28,11 +35,34 @@ const makeWrapper = (middleware) => (WrappedComponent) => {
       }))
     }
 
+    initInputFlags = (name) => {
+      if (!this.inputFlags[name]) {
+        this.setInputFlags(name, {
+          dirty: false,
+          pristine: true,
+          touched: false,
+          untouched: true
+        })
+      }
+    }
+
+    setInputFlags = (name, flags) => {
+      const merged = assign({}, this.inputFlags[name], flags)
+      const inverse = {
+        pristine: !merged.dirty,
+        untouched: !merged.touched
+      }
+
+      this.inputFlags[name] = assign({}, merged, inverse)
+      return this.inputFlags
+    }
+
     // This, of course, does not handle all possible inputs. In such cases,
     // you should just use `setProperty` or `setModel`. Or, better yet,
     // extend `reformed` to supply the bindings that match your needs.
     bindToChangeEvent = (e) => {
       const { name, type, value } = e.target
+      const newFlags = { dirty: true }
 
       if (type === 'checkbox') {
         const oldCheckboxValue = this.state.model[name] || []
@@ -40,42 +70,63 @@ const makeWrapper = (middleware) => (WrappedComponent) => {
           ? oldCheckboxValue.concat(value)
           : oldCheckboxValue.filter(v => v !== value)
 
+        newFlags.touched = true
         this.setProperty(name, newCheckboxValue)
       } else {
         this.setProperty(name, value)
       }
+
+      this.setInputFlags(name, newFlags)
     }
 
-    bindInput = (name, opts) => {
-      const cfg = assign({
-        updateOn: 'onChange',
-        debounce: 0
-      }, opts)
-
-      const { updateOn } = cfg
-      const asyncHandler = (fn) => (e) => {
-        e.persist()
-        fn(e)
-      }
-
-      const updater = (!cfg.debounce)
-        ? this.bindToChangeEvent
-        : asyncHandler(debounce(this.bindToChangeEvent, cfg.debounce, false))
-
+    bindInput = (name) => {
+      this.initInputFlags(name)
       return {
         name,
-        defaultValue: this.state.model[name] || '',
-        [updateOn]: updater
+        value: this.state.model[name] || '',
+        onChange: this.onInputEvent,
+        onBlur: this.onInputEvent,
+        onFocus: this.onInputEvent
       }
+    }
+
+    bindCheckbox = (name, value) => {
+      this.initInputFlags(name)
+      return {
+        name,
+        checked: contains(value, this.state.model[name]),
+        onChange: this.onInputEvent,
+        onBlur: this.onInputEvent,
+        onFocus: this.onInputEvent
+      }
+    }
+
+    onInputEvent = (e) => {
+      const { target, type } = e
+      const { name } = target
+      const lastInputEvent = { name, target, type }
+
+      this.setState({ lastInputEvent })
+      if (type === 'change') this.bindToChangeEvent(e)
+      if (type === 'blur') this.setInputFlags(name, { touched: true })
+    }
+
+    componentDidMount = () => {
+      // Once downstream inputs are bound and `inputFlags`
+      // has been set, force an update
+      this.forceUpdate()
     }
 
     render () {
       const nextProps = assign({}, this.props, {
         bindInput: this.bindInput,
+        bindCheckbox: this.bindCheckbox,
         bindToChangeEvent: this.bindToChangeEvent,
         model: this.state.model,
         setProperty: this.setProperty,
         setModel: this.setModel,
+        lastInputEvent: this.state.lastInputEvent,
+        inputFlags: assign({}, this.inputFlags)
       })
       // SIDE EFFECT-ABLE. Just for developer convenience and expirementation.
       const finalProps = typeof middleware === 'function'

--- a/src/reformed.js
+++ b/src/reformed.js
@@ -54,8 +54,8 @@ const makeWrapper = (middleware) => (WrappedComponent) => {
 
       const { updateOn } = cfg
       const asyncHandler = (fn) => (e) => {
-        e.persist();
-        fn(e);
+        e.persist()
+        fn(e)
       }
 
       const updater = (!cfg.debounce)

--- a/src/reformed.js
+++ b/src/reformed.js
@@ -47,7 +47,7 @@ const makeWrapper = (middleware) => (WrappedComponent) => {
     }
 
     bindInput = (name, opts) => {
-      const cfg = Object.assign({
+      const cfg = assign({
         updateOn: 'onChange',
         debounce: 0
       }, opts)

--- a/src/reformed.js
+++ b/src/reformed.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import debounce from 'debounce'
 import assign from 'object-assign'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import getComponentName from './_internal/getComponentName'
@@ -45,11 +46,26 @@ const makeWrapper = (middleware) => (WrappedComponent) => {
       }
     }
 
-    bindInput = (name) => {
+    bindInput = (name, opts) => {
+      const cfg = Object.assign({
+        updateOn: 'onChange',
+        debounce: 0
+      }, opts)
+
+      const { updateOn } = cfg
+      const asyncHandler = (fn) => (e) => {
+        e.persist();
+        fn(e);
+      }
+
+      const updater = (!cfg.debounce)
+        ? this.bindToChangeEvent
+        : asyncHandler(debounce(this.bindToChangeEvent, cfg.debounce, false))
+
       return {
         name,
-        value: this.state.model[name] || '',
-        onChange: this.bindToChangeEvent,
+        defaultValue: this.state.model[name] || '',
+        [updateOn]: updater
       }
     }
 


### PR DESCRIPTION
Hey Dave, me again 😁 . Currently since the library uses the `onChange` handler to persist model updates and perform validation, validation errors for `minLength` or `maxLength` will display immediately as the user types, without giving them a chance to complete their input. This can be a little annoying and confusing in certain instances.

Angular and other libraries typically handle this by providing options to evaluate on blur or by using a debounce. This is an implementation of that approach which modifies `bindInput` to allow the user to configure each binding as appropriate.

Note: the `asyncHandler` is required due to React's event pooling (see: https://facebook.github.io/react/docs/events.html#event-pooling).