### PR TITLE
fix(compose): allow composition

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -1,6 +1,6 @@
 export default function compose (..._fns) {
+  const [fn, ...fns] = _fns.reverse()
   return (...args) => {
-    const [fn, ...fns] = _fns.reverse()
     return fns.reduce((acc, f) => f(acc), fn(...args))
   }
 }


### PR DESCRIPTION
Hi. The compose function wasn't functioning correctly. It reversed the functions on every call to the returned function (the example below is better than any way I can explain it).

```javascript
> function compose (..._fns) {
...   return (...args) => {
.....     const [fn, ...fns] = _fns.reverse()
.....     return fns.reduce((acc, f) => f(acc), fn(...args))
.....   }
... }
> const a = v => v*2
> const b = v => v+3
> const ab = compose(a, b)
> ab(1)
8
> ab(1)
5
> ab(1)
8
> ab(1)
5
> function compose_fix (..._fns) {
...   const [fn, ...fns] = _fns.reverse()
...   return (...args) => {
.....     return fns.reduce((acc, f) => f(acc), fn(...args))
.....   }
... }
> const ab2 = compose_fix(a, b)
> ab2(1)
8
> ab2(1)
8
> ab2(1)
8
> ab2(1)
8
```