### PR TITLE
fix(bindInput): reference final version of `setProperty`

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -75,7 +75,13 @@ const MyForm = ({ bindInput, bindToChangeEvent, model, onSubmit, setProperty, sc
  * to sync to local storage.
  */
 const createFormContainer = compose(
-  reformed(),
+  reformed(({ setProperty, ...rest }) => ({
+    ...rest,
+    setProperty: (name, value) => {
+      console.log('Spied on setProperty: ', { name, value })
+      return setProperty(name, value)
+    }
+  })),
   // Let's try out some schema validation...
   validateSchema({
     username: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-reformed",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Tiny form bindings for React",
   "main": "lib/reformed.js",
   "scripts": {


### PR DESCRIPTION
Fixes #20 by ensuring that `bindInput` references `setProperty` _after_ middleware has been applied. Previously, if the middleware modified `setProperty`, `bindInput` would continue to reference the original version.